### PR TITLE
stream methods using Flows instead of Channels

### DIFF
--- a/app/src/main/java/com/nytimes/android/sample/StreamActivity.kt
+++ b/app/src/main/java/com/nytimes/android/sample/StreamActivity.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import com.nytimes.android.external.store3.base.impl.MemoryPolicy
 import com.nytimes.android.external.store3.base.impl.StoreBuilder
 import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.collect
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 
@@ -49,17 +49,17 @@ class StreamActivity : AppCompatActivity(), CoroutineScope {
         }
 
         launch {
-            store.stream(1).consumeEach {
+            store.stream(1).collect {
                 findViewById<TextView>(R.id.stream_1).text = "Stream 1 $it"
             }
         }
         launch {
-            store.stream(2).consumeEach {
+            store.stream(2).collect {
                 findViewById<TextView>(R.id.stream_2).text = "Stream 2 $it"
             }
         }
         launch {
-            store.stream().consumeEach {
+            store.stream().collect {
                 findViewById<TextView>(R.id.stream).text = "Stream $it"
             }
         }

--- a/filesystem/src/test/java/com/nytimes/android/external/fs3/StoreNetworkBeforeStaleFailTest.kt
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs3/StoreNetworkBeforeStaleFailTest.kt
@@ -1,5 +1,7 @@
 package com.nytimes.android.external.fs3
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.nytimes.android.external.store3.base.Fetcher
@@ -17,7 +19,13 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class StoreNetworkBeforeStaleFailTest {
-    private val fetcher: Fetcher<BufferedSource, BarCode> = mock()
+    private val fetcher: Fetcher<BufferedSource, BarCode> = mock{
+        runBlocking {
+            on(it.fetch(any())) doAnswer {
+                null
+            }
+        }
+    }
     private val store = StoreBuilder.barcode<BufferedSource>()
             .fetcher(fetcher)
             .persister(TestPersister())

--- a/filesystem/src/test/java/com/nytimes/android/external/fs3/StoreNetworkBeforeStaleFailTest.kt
+++ b/filesystem/src/test/java/com/nytimes/android/external/fs3/StoreNetworkBeforeStaleFailTest.kt
@@ -1,7 +1,5 @@
 package com.nytimes.android.external.fs3
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.nytimes.android.external.store3.base.Fetcher
@@ -19,13 +17,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 
 class StoreNetworkBeforeStaleFailTest {
-    private val fetcher: Fetcher<BufferedSource, BarCode> = mock{
-        runBlocking {
-            on(it.fetch(any())) doAnswer {
-                null
-            }
-        }
-    }
+    private val fetcher: Fetcher<BufferedSource, BarCode> = mock()
     private val store = StoreBuilder.barcode<BufferedSource>()
             .fetcher(fetcher)
             .persister(TestPersister())

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealInternalStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealInternalStore.kt
@@ -21,200 +21,200 @@ import java.util.concurrent.ConcurrentMap
  * Example usage:  @link
 </Parsed></Raw> */
 internal class RealInternalStore<Raw, Parsed, Key>(
-        private val fetcher: Fetcher<Raw, Key>,
-        private val persister: Persister<Raw, Key>,
-        private val parser: KeyParser<Key, Raw, Parsed>,
-        memoryPolicy: MemoryPolicy?,
-        private val stalePolicy: StalePolicy
+  private val fetcher: Fetcher<Raw, Key>,
+  private val persister: Persister<Raw, Key>,
+  private val parser: KeyParser<Key, Raw, Parsed>,
+  memoryPolicy: MemoryPolicy?,
+  private val stalePolicy: StalePolicy
 ) :
-        Fetcher<Raw, Key> by fetcher,
-        Persister<Raw, Key> by persister,
-        KeyParser<Key, Raw, Parsed> by parser,
-        InternalStore<Parsed, Key> {
-    private val inFlightRequests: Cache<Key, Deferred<Parsed>> = CacheFactory.createInflighter(memoryPolicy)
-    var memCache: Cache<Key, Deferred<Parsed>> = CacheFactory.createCache(memoryPolicy)
-    private val inFlightScope = CoroutineScope(SupervisorJob())
-    private val memoryScope = CoroutineScope(SupervisorJob())
-    //  private val refreshSubject = PublishSubject.create<Key>()
-    private val subject = BroadcastChannel<Pair<Key, Parsed>?>(CONFLATED).apply {
-        //a conflated channel always maintains the last element, the stream method ignore this element.
-        //Here we add an empty element that will be ignored later
-        offer(null)
-    }
+    Fetcher<Raw, Key> by fetcher,
+    Persister<Raw, Key> by persister,
+    KeyParser<Key, Raw, Parsed> by parser,
+    InternalStore<Parsed, Key> {
+  private val inFlightRequests: Cache<Key, Deferred<Parsed>> = CacheFactory.createInflighter(memoryPolicy)
+  var memCache: Cache<Key, Deferred<Parsed>> = CacheFactory.createCache(memoryPolicy)
+  private val inFlightScope = CoroutineScope(SupervisorJob())
+  private val memoryScope = CoroutineScope(SupervisorJob())
+//  private val refreshSubject = PublishSubject.create<Key>()
+  private val subject = BroadcastChannel<Pair<Key, Parsed>?>(CONFLATED).apply {
+    //a conflated channel always maintains the last element, the stream method ignore this element.
+    //Here we add an empty element that will be ignored later
+    offer(null)
+  }
 
-    constructor(
-            fetcher: Fetcher<Raw, Key>,
-            persister: Persister<Raw, Key>,
-            parser: KeyParser<Key, Raw, Parsed>,
-            stalePolicy: StalePolicy
-    ) : this(fetcher, persister, parser, null, stalePolicy)
+  constructor(
+    fetcher: Fetcher<Raw, Key>,
+    persister: Persister<Raw, Key>,
+    parser: KeyParser<Key, Raw, Parsed>,
+    stalePolicy: StalePolicy
+  ) : this(fetcher, persister, parser, null, stalePolicy)
 
-    /**
-     * @param key
-     * @return an observable from the first data source that is available
-     */
-    override suspend fun get(key: Key): Parsed =
-            withContext(Dispatchers.IO) {
-                try {
-                    memCache.get(key) {
-                        memoryScope.async {
-                            disk(key) ?: fresh(key)
-                        }
-                    }
-                            .await()
-                } catch (e: Exception) {
-                    // should we remove the key from the cache here ?
-                    disk(key) ?: fresh(key)
-                }
+  /**
+   * @param key
+   * @return an observable from the first data source that is available
+   */
+  override suspend fun get(key: Key): Parsed =
+      withContext(Dispatchers.IO) {
+        try {
+          memCache.get(key) {
+            memoryScope.async {
+              disk(key) ?: fresh(key)
             }
-
-
-    /**
-     * Fetch data from persister and update memory after. If an error occurs, emit an empty observable
-     * so that the concat call in [.get] moves on to [.fresh]
-     *
-     * @param key
-     * @return
-     */
-    override suspend fun disk(key: Key): Parsed? {
-        return if (StoreUtil.shouldReturnNetworkBeforeStale<Raw, Key>(persister, stalePolicy, key)) {
-            null
-        } else readDisk(key)
-
-    }
-
-    suspend fun readDisk(key: Key): Parsed? {
-        return try {
-            val diskValue: Parsed? = read(key)
-                    ?.let { apply(key, it) }
-            if (stalePolicy == StalePolicy.REFRESH_ON_STALE && StoreUtil.persisterIsStale<Any, Key>(key, persister)) {
-                backfillCache(key)
-            }
-            diskValue
+          }
+              .await()
         } catch (e: Exception) {
-            //store fetching acts as a fallthrough,
-            // if we error on disk fetching we should return no data rather than throwing the error
-            null
+          // should we remove the key from the cache here ?
+          disk(key) ?: fresh(key)
+        }
+      }
+
+
+  /**
+   * Fetch data from persister and update memory after. If an error occurs, emit an empty observable
+   * so that the concat call in [.get] moves on to [.fresh]
+   *
+   * @param key
+   * @return
+   */
+  override suspend fun disk(key: Key): Parsed? {
+    return if (StoreUtil.shouldReturnNetworkBeforeStale<Raw, Key>(persister, stalePolicy, key)) {
+      null
+    } else readDisk(key)
+
+  }
+
+  suspend fun readDisk(key: Key): Parsed? {
+    return try {
+      val diskValue: Parsed? = read(key)
+          ?.let { apply(key, it) }
+      if (stalePolicy == StalePolicy.REFRESH_ON_STALE && StoreUtil.persisterIsStale<Any, Key>(key, persister)) {
+        backfillCache(key)
+      }
+      diskValue
+    } catch (e: Exception) {
+      //store fetching acts as a fallthrough,
+      // if we error on disk fetching we should return no data rather than throwing the error
+      null
+    }
+  }
+
+  private fun updateMemory(
+    key: Key,
+    it: Parsed
+  ) {
+    memCache.put(key, memoryScope.async { it })
+  }
+
+  suspend fun backfillCache(key: Key) {
+    fresh(key)
+  }
+
+  /**
+   * Will check to see if there exists an in flight observable and return it before
+   * going to network
+   *
+   * @return data from fresh and store it in memory and persister
+   */
+  override suspend fun fresh(key: Key): Parsed =
+    withContext(Dispatchers.IO) {
+        fetchAndPersist(key).also {
+            updateMemory(key, it)
         }
     }
 
-    private fun updateMemory(
-            key: Key,
-            it: Parsed
-    ) {
-        memCache.put(key, memoryScope.async { it })
+  /**
+   * There should only be one fresh request in flight at any give time.
+   *
+   *
+   * Return cached request in the form of a Behavior Subject which will emit to its subscribers
+   * the last value it gets. Subject/Observable is cached in a [ConcurrentMap] to maintain
+   * thread safety.
+   *
+   * @param key resource identifier
+   * @return observable that emits a [Parsed] value
+   */
+  suspend fun fetchAndPersist(key: Key): Parsed =
+    inFlightRequests
+        .get(key) { inFlightScope.async { response(key) } }
+        .await()
+
+  suspend fun response(key: Key): Parsed {
+    return try {
+      val fetchedValue = fetch(key)
+      write(key, fetchedValue)
+      val diskValue = readDisk(key)!!
+      notifySubscribers(diskValue, key)
+      return diskValue
+    } catch (e: Exception) {
+      handleNetworkError(key, e)
+    } finally {
+      inFlightRequests.invalidate(key)
     }
+  }
 
-    suspend fun backfillCache(key: Key) {
-        fresh(key)
+  suspend fun handleNetworkError(
+    key: Key,
+    throwable: Throwable
+  ): Parsed {
+    if (stalePolicy == StalePolicy.NETWORK_BEFORE_STALE) {
+      val diskValue = readDisk(key)
+      if (diskValue != null)
+        return diskValue else throw throwable
     }
+    throw throwable
+  }
 
-    /**
-     * Will check to see if there exists an in flight observable and return it before
-     * going to network
-     *
-     * @return data from fresh and store it in memory and persister
-     */
-    override suspend fun fresh(key: Key): Parsed =
-            withContext(Dispatchers.IO) {
-                fetchAndPersist(key).also {
-                    updateMemory(key, it)
-                }
-            }
+  suspend fun notifySubscribers(
+    data: Parsed,
+    key: Key
+  ) {
+    subject.send(key to data)
+  }
 
-    /**
-     * There should only be one fresh request in flight at any give time.
-     *
-     *
-     * Return cached request in the form of a Behavior Subject which will emit to its subscribers
-     * the last value it gets. Subject/Observable is cached in a [ConcurrentMap] to maintain
-     * thread safety.
-     *
-     * @param key resource identifier
-     * @return observable that emits a [Parsed] value
-     */
-    suspend fun fetchAndPersist(key: Key): Parsed =
-            inFlightRequests
-                    .get(key) { inFlightScope.async { response(key) } }
-                    .await()
+  //STREAM NO longer calls get
+  override fun stream(key: Key): Flow<Parsed> =
+      streamSubscription().filter { it.first == key }.map { (_, value) -> value }
 
-    suspend fun response(key: Key): Parsed {
-        return try {
-            val fetchedValue = fetch(key)
-            write(key, fetchedValue)
-            val diskValue = readDisk(key)!!
-            notifySubscribers(diskValue, key)
-            return diskValue
-        } catch (e: Exception) {
-            handleNetworkError(key, e)
-        } finally {
-            inFlightRequests.invalidate(key)
-        }
+  override fun stream(): Flow<Parsed> {
+    return streamSubscription().map { (_, value) -> value }
+  }
+
+  private fun streamSubscription() =
+      subject.asFlow()
+          //ignore first element so only new elements are returned
+          .drop(1)
+          .map { it!! }
+
+  @Deprecated("")
+  override fun clearMemory() {
+    clear()
+  }
+
+  /**
+   * Clear memory by id
+   *
+   * @param key of data to clear
+   */
+  @Deprecated("")
+  override fun clearMemory(key: Key) {
+    clear(key)
+  }
+
+  override fun clear() {
+    for (cachedKey in memCache.asMap().keys) {
+      clear(cachedKey)
     }
+  }
 
-    suspend fun handleNetworkError(
-            key: Key,
-            throwable: Throwable
-    ): Parsed {
-        if (stalePolicy == StalePolicy.NETWORK_BEFORE_STALE) {
-            val diskValue = readDisk(key)
-            if (diskValue != null)
-                return diskValue else throw throwable
-        }
-        throw throwable
-    }
+  override fun clear(key: Key) {
+    inFlightRequests.invalidate(key)
+    memCache.invalidate(key)
+    StoreUtil.clearPersister<Any, Key>(persister, key)
+    notifyRefresh(key)
+  }
 
-    suspend fun notifySubscribers(
-            data: Parsed,
-            key: Key
-    ) {
-        subject.send(key to data)
-    }
-
-    //STREAM NO longer calls get
-    override fun stream(key: Key): Flow<Parsed> =
-            streamSubscription().filter { it.first == key }.map { (_, value) -> value }
-
-    override fun stream(): Flow<Parsed> {
-        return streamSubscription().map { (_, value) -> value }
-    }
-
-    private fun streamSubscription() =
-            subject.asFlow()
-                    //ignore first element so only new elements are returned
-                    .drop(1)
-                    .map { it!! }
-
-    @Deprecated("")
-    override fun clearMemory() {
-        clear()
-    }
-
-    /**
-     * Clear memory by id
-     *
-     * @param key of data to clear
-     */
-    @Deprecated("")
-    override fun clearMemory(key: Key) {
-        clear(key)
-    }
-
-    override fun clear() {
-        for (cachedKey in memCache.asMap().keys) {
-            clear(cachedKey)
-        }
-    }
-
-    override fun clear(key: Key) {
-        inFlightRequests.invalidate(key)
-        memCache.invalidate(key)
-        StoreUtil.clearPersister<Any, Key>(persister, key)
-        notifyRefresh(key)
-    }
-
-    private fun notifyRefresh(key: Key) {
+  private fun notifyRefresh(key: Key) {
 //    refreshSubject.onNext(key)
-    }
+  }
 }
 

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealInternalStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealInternalStore.kt
@@ -8,9 +8,7 @@ import com.nytimes.android.external.store3.util.KeyParser
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
-import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.channels.filter
-import kotlinx.coroutines.channels.map
+import kotlinx.coroutines.flow.*
 import java.util.concurrent.ConcurrentMap
 
 /**
@@ -23,201 +21,200 @@ import java.util.concurrent.ConcurrentMap
  * Example usage:  @link
 </Parsed></Raw> */
 internal class RealInternalStore<Raw, Parsed, Key>(
-  private val fetcher: Fetcher<Raw, Key>,
-  private val persister: Persister<Raw, Key>,
-  private val parser: KeyParser<Key, Raw, Parsed>,
-  memoryPolicy: MemoryPolicy?,
-  private val stalePolicy: StalePolicy
+        private val fetcher: Fetcher<Raw, Key>,
+        private val persister: Persister<Raw, Key>,
+        private val parser: KeyParser<Key, Raw, Parsed>,
+        memoryPolicy: MemoryPolicy?,
+        private val stalePolicy: StalePolicy
 ) :
-    Fetcher<Raw, Key> by fetcher,
-    Persister<Raw, Key> by persister,
-    KeyParser<Key, Raw, Parsed> by parser,
-    InternalStore<Parsed, Key> {
-  private val inFlightRequests: Cache<Key, Deferred<Parsed>> = CacheFactory.createInflighter(memoryPolicy)
-  var memCache: Cache<Key, Deferred<Parsed>> = CacheFactory.createCache(memoryPolicy)
-  private val inFlightScope = CoroutineScope(SupervisorJob())
-  private val memoryScope = CoroutineScope(SupervisorJob())
-//  private val refreshSubject = PublishSubject.create<Key>()
-  private val subject = BroadcastChannel<Pair<Key, Parsed>?>(CONFLATED).apply {
-    //a conflated channel always maintains the last element, the stream method ignore this element.
-    //Here we add an empty element that will be ignored later
-    offer(null)
-  }
+        Fetcher<Raw, Key> by fetcher,
+        Persister<Raw, Key> by persister,
+        KeyParser<Key, Raw, Parsed> by parser,
+        InternalStore<Parsed, Key> {
+    private val inFlightRequests: Cache<Key, Deferred<Parsed>> = CacheFactory.createInflighter(memoryPolicy)
+    var memCache: Cache<Key, Deferred<Parsed>> = CacheFactory.createCache(memoryPolicy)
+    private val inFlightScope = CoroutineScope(SupervisorJob())
+    private val memoryScope = CoroutineScope(SupervisorJob())
+    //  private val refreshSubject = PublishSubject.create<Key>()
+    private val subject = BroadcastChannel<Pair<Key, Parsed>?>(CONFLATED).apply {
+        //a conflated channel always maintains the last element, the stream method ignore this element.
+        //Here we add an empty element that will be ignored later
+        offer(null)
+    }
 
-  constructor(
-    fetcher: Fetcher<Raw, Key>,
-    persister: Persister<Raw, Key>,
-    parser: KeyParser<Key, Raw, Parsed>,
-    stalePolicy: StalePolicy
-  ) : this(fetcher, persister, parser, null, stalePolicy)
+    constructor(
+            fetcher: Fetcher<Raw, Key>,
+            persister: Persister<Raw, Key>,
+            parser: KeyParser<Key, Raw, Parsed>,
+            stalePolicy: StalePolicy
+    ) : this(fetcher, persister, parser, null, stalePolicy)
 
-  /**
-   * @param key
-   * @return an observable from the first data source that is available
-   */
-  override suspend fun get(key: Key): Parsed =
-    withContext(Dispatchers.IO) {
-      try {
-          memCache.get(key) {
-            memoryScope.async {
-              disk(key) ?: fresh(key)
+    /**
+     * @param key
+     * @return an observable from the first data source that is available
+     */
+    override suspend fun get(key: Key): Parsed =
+            withContext(Dispatchers.IO) {
+                try {
+                    memCache.get(key) {
+                        memoryScope.async {
+                            disk(key) ?: fresh(key)
+                        }
+                    }
+                            .await()
+                } catch (e: Exception) {
+                    // should we remove the key from the cache here ?
+                    disk(key) ?: fresh(key)
+                }
             }
-          }
-                  .await()
-      } catch (e: Exception) {
-        // should we remove the key from the cache here ?
-        disk(key) ?: fresh(key)
-      }
+
+
+    /**
+     * Fetch data from persister and update memory after. If an error occurs, emit an empty observable
+     * so that the concat call in [.get] moves on to [.fresh]
+     *
+     * @param key
+     * @return
+     */
+    override suspend fun disk(key: Key): Parsed? {
+        return if (StoreUtil.shouldReturnNetworkBeforeStale<Raw, Key>(persister, stalePolicy, key)) {
+            null
+        } else readDisk(key)
+
     }
 
-
-
-  /**
-   * Fetch data from persister and update memory after. If an error occurs, emit an empty observable
-   * so that the concat call in [.get] moves on to [.fresh]
-   *
-   * @param key
-   * @return
-   */
-  override suspend fun disk(key: Key): Parsed? {
-    return if (StoreUtil.shouldReturnNetworkBeforeStale<Raw, Key>(persister, stalePolicy, key)) {
-      null
-    } else readDisk(key)
-
-  }
-
-  suspend fun readDisk(key: Key): Parsed? {
-    return try {
-      val diskValue: Parsed? = read(key)
-          ?.let { apply(key, it) }
-      if (stalePolicy == StalePolicy.REFRESH_ON_STALE && StoreUtil.persisterIsStale<Any, Key>(key, persister)) {
-        backfillCache(key)
-      }
-      diskValue
-    } catch (e: Exception) {
-      //store fetching acts as a fallthrough,
-      // if we error on disk fetching we should return no data rather than throwing the error
-      null
-    }
-  }
-
-  private fun updateMemory(
-    key: Key,
-    it: Parsed
-  ) {
-    memCache.put(key, memoryScope.async { it })
-  }
-
-  suspend fun backfillCache(key: Key) {
-    fresh(key)
-  }
-
-  /**
-   * Will check to see if there exists an in flight observable and return it before
-   * going to network
-   *
-   * @return data from fresh and store it in memory and persister
-   */
-  override suspend fun fresh(key: Key): Parsed =
-    withContext(Dispatchers.IO) {
-        fetchAndPersist(key).also {
-            updateMemory(key, it)
+    suspend fun readDisk(key: Key): Parsed? {
+        return try {
+            val diskValue: Parsed? = read(key)
+                    ?.let { apply(key, it) }
+            if (stalePolicy == StalePolicy.REFRESH_ON_STALE && StoreUtil.persisterIsStale<Any, Key>(key, persister)) {
+                backfillCache(key)
+            }
+            diskValue
+        } catch (e: Exception) {
+            //store fetching acts as a fallthrough,
+            // if we error on disk fetching we should return no data rather than throwing the error
+            null
         }
     }
 
-  /**
-   * There should only be one fresh request in flight at any give time.
-   *
-   *
-   * Return cached request in the form of a Behavior Subject which will emit to its subscribers
-   * the last value it gets. Subject/Observable is cached in a [ConcurrentMap] to maintain
-   * thread safety.
-   *
-   * @param key resource identifier
-   * @return observable that emits a [Parsed] value
-   */
-  suspend fun fetchAndPersist(key: Key): Parsed =
-    inFlightRequests
-        .get(key) { inFlightScope.async { response(key) } }
-        .await()
-
-  suspend fun response(key: Key): Parsed {
-    return try {
-      val fetchedValue = fetch(key)
-      write(key, fetchedValue)
-      val diskValue = readDisk(key)!!
-      notifySubscribers(diskValue, key)
-      return diskValue
-    } catch (e: Exception) {
-      handleNetworkError(key, e)
-    } finally {
-      inFlightRequests.invalidate(key)
+    private fun updateMemory(
+            key: Key,
+            it: Parsed
+    ) {
+        memCache.put(key, memoryScope.async { it })
     }
-  }
 
-  suspend fun handleNetworkError(
-    key: Key,
-    throwable: Throwable
-  ): Parsed {
-    if (stalePolicy == StalePolicy.NETWORK_BEFORE_STALE) {
-      val diskValue = readDisk(key)
-      if (diskValue != null)
-        return diskValue else throw throwable
+    suspend fun backfillCache(key: Key) {
+        fresh(key)
     }
-    throw throwable
-  }
 
-  suspend fun notifySubscribers(
-    data: Parsed,
-    key: Key
-  ) {
-    subject.send(key to data)
-  }
+    /**
+     * Will check to see if there exists an in flight observable and return it before
+     * going to network
+     *
+     * @return data from fresh and store it in memory and persister
+     */
+    override suspend fun fresh(key: Key): Parsed =
+            withContext(Dispatchers.IO) {
+                fetchAndPersist(key).also {
+                    updateMemory(key, it)
+                }
+            }
 
-  //STREAM NO longer calls get
-  override fun stream(key: Key): ReceiveChannel<Parsed> =
-    streamSubscription().filter { it.first == key }.map { (_, value) -> value }
+    /**
+     * There should only be one fresh request in flight at any give time.
+     *
+     *
+     * Return cached request in the form of a Behavior Subject which will emit to its subscribers
+     * the last value it gets. Subject/Observable is cached in a [ConcurrentMap] to maintain
+     * thread safety.
+     *
+     * @param key resource identifier
+     * @return observable that emits a [Parsed] value
+     */
+    suspend fun fetchAndPersist(key: Key): Parsed =
+            inFlightRequests
+                    .get(key) { inFlightScope.async { response(key) } }
+                    .await()
 
-  override fun stream(): ReceiveChannel<Parsed> {
-    return streamSubscription().map { (_, value) -> value }
-  }
-
-  private fun streamSubscription() =
-          subject.openSubscription()
-                  //ignore first element so only new elements are returned
-                  .apply { poll() }
-                  .map { it!! }
-
-  @Deprecated("")
-  override fun clearMemory() {
-    clear()
-  }
-
-  /**
-   * Clear memory by id
-   *
-   * @param key of data to clear
-   */
-  @Deprecated("")
-  override fun clearMemory(key: Key) {
-    clear(key)
-  }
-
-  override fun clear() {
-    for (cachedKey in memCache.asMap().keys) {
-      clear(cachedKey)
+    suspend fun response(key: Key): Parsed {
+        return try {
+            val fetchedValue = fetch(key)
+            write(key, fetchedValue)
+            val diskValue = readDisk(key)!!
+            notifySubscribers(diskValue, key)
+            return diskValue
+        } catch (e: Exception) {
+            handleNetworkError(key, e)
+        } finally {
+            inFlightRequests.invalidate(key)
+        }
     }
-  }
 
-  override fun clear(key: Key) {
-    inFlightRequests.invalidate(key)
-    memCache.invalidate(key)
-    StoreUtil.clearPersister<Any, Key>(persister, key)
-    notifyRefresh(key)
-  }
+    suspend fun handleNetworkError(
+            key: Key,
+            throwable: Throwable
+    ): Parsed {
+        if (stalePolicy == StalePolicy.NETWORK_BEFORE_STALE) {
+            val diskValue = readDisk(key)
+            if (diskValue != null)
+                return diskValue else throw throwable
+        }
+        throw throwable
+    }
 
-  private fun notifyRefresh(key: Key) {
+    suspend fun notifySubscribers(
+            data: Parsed,
+            key: Key
+    ) {
+        subject.send(key to data)
+    }
+
+    //STREAM NO longer calls get
+    override fun stream(key: Key): Flow<Parsed> =
+            streamSubscription().filter { it.first == key }.map { (_, value) -> value }
+
+    override fun stream(): Flow<Parsed> {
+        return streamSubscription().map { (_, value) -> value }
+    }
+
+    private fun streamSubscription() =
+            subject.asFlow()
+                    //ignore first element so only new elements are returned
+                    .drop(1)
+                    .map { it!! }
+
+    @Deprecated("")
+    override fun clearMemory() {
+        clear()
+    }
+
+    /**
+     * Clear memory by id
+     *
+     * @param key of data to clear
+     */
+    @Deprecated("")
+    override fun clearMemory(key: Key) {
+        clear(key)
+    }
+
+    override fun clear() {
+        for (cachedKey in memCache.asMap().keys) {
+            clear(cachedKey)
+        }
+    }
+
+    override fun clear(key: Key) {
+        inFlightRequests.invalidate(key)
+        memCache.invalidate(key)
+        StoreUtil.clearPersister<Any, Key>(persister, key)
+        notifyRefresh(key)
+    }
+
+    private fun notifyRefresh(key: Key) {
 //    refreshSubject.onNext(key)
-  }
+    }
 }
 

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealStore.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/RealStore.kt
@@ -8,7 +8,7 @@ import com.nytimes.android.external.store3.util.KeyParser
 import com.nytimes.android.external.store3.util.NoKeyParser
 import com.nytimes.android.external.store3.util.NoopParserFunc
 import com.nytimes.android.external.store3.util.NoopPersister
-import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.Flow
 
 open class RealStore<Parsed, Key> : Store<Parsed, Key> {
 
@@ -81,16 +81,16 @@ open class RealStore<Parsed, Key> : Store<Parsed, Key> {
      *
      * @return data from fresh and store it in memory and persister
      */
-    suspend override fun fresh(key: Key): Parsed {
+    override suspend fun fresh(key: Key): Parsed {
         return internalStore.fresh(key)
     }
 
 
-    override fun stream(): ReceiveChannel<Parsed> {
+    override fun stream(): Flow<Parsed> {
         return internalStore.stream()
     }
 
-    override fun stream(key: Key): ReceiveChannel<Parsed> {
+    override fun stream(key: Key): Flow<Parsed> {
         return internalStore.stream(key)
     }
 

--- a/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.kt
+++ b/store/src/main/java/com/nytimes/android/external/store3/base/impl/Store.kt
@@ -1,7 +1,7 @@
 package com.nytimes.android.external.store3.base.impl
 
 import com.nytimes.android.external.store.util.Result
-import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.flow.Flow
 
 /**
  * a [StoreBuilder]
@@ -54,7 +54,7 @@ interface Store<T, V> {
      * with operators that expect an OnComplete event
      */
     // TODO should this method return a Pair<K, T> ?
-    fun stream(): ReceiveChannel<T>
+    fun stream(): Flow<T>
 
     /**
      * Similar to  [Store.get() ][Store.get]
@@ -63,7 +63,7 @@ interface Store<T, V> {
      * Errors will be dropped
      *
      */
-    fun stream(key: V): ReceiveChannel<T>
+    fun stream(key: V): Flow<T>
 
     /**
      * Clear the memory cache of all entries


### PR DESCRIPTION
This PR changes the two `stream` methods to return a `Flow<Parsed>` instead of a `ReceiveChannel<Parsed>`. Internally a `Channel` is still used to collect the changes, it's converted to a `Flow` only when a `stream` method is invoked. 